### PR TITLE
Feature/zen 18191

### DIFF
--- a/lpu/zenoss-audit-lpu.ps1
+++ b/lpu/zenoss-audit-lpu.ps1
@@ -85,6 +85,7 @@ else{
 	$domain = $env:COMPUTERNAME
 	$username = $login
 	$userfqdn = "{1}\{0}" -f $username, $domain
+    $domainuser = $userfqdn
 }
 
 # Prep event Log
@@ -137,21 +138,29 @@ function is_user_in_group($groupname) {
 }
 
 function is_user_in_service($service){
-    $testusersddl = "(A;;CCLCRPLORC;;;{0})" -f $usersid
+    $testuserperms = @('CC','LC','RP','LO','RC')
 	$servicesddlstart = [string](CMD /C "sc sdshow `"$service`"")
-	return $servicesddlstart.contains($testusersddl)
+    $intersection = @('place','holder')
+    foreach ($sddlkey in $servicesddlstart.split('('))  {
+        if ($sddlkey -match $usersid) {
+            $perms = [regex]::match($sddlkey, '\w;;(\w+);.*').Groups[1].value
+            $sddlperms = $perms -split '(.{2})' | ? {$_}
+            $intersection = $testuserperms | ?{$sddlperms -notcontains $_}
+        }
+    }
+	return $intersection -eq $null
 }
 
 function test_folderfile($folderfile){
 	if(Test-Path $folderfile){
 		$folderfileacl = (get-item $folderfile).getaccesscontrol("Access")
         $folderfileaclstring = $folderfileacl.AccessToString
-        $testuser = "{0} Allow  ReadFolder" -f $domainuser
+        $testuser = "{0}\s+Allow\s+ReadFolder" -f $domainuser.replace('\', '\\')
         if ($_debug) {
             Write-Host "debug: `$testuser = $testuser"
             Write-Host "debug: `$folderfileacl = $folderfileacl"
         }
-        return $folderfileaclstring.Contains($testuser) 
+        return $folderfileaclstring -match $testuser
 	}
 
 	trap{
@@ -164,7 +173,7 @@ function test_folderfile($folderfile){
 
 function test_registry_security($regkey){
 	if(Test-Path $regkey){
-        $testuser = "{0} Allow  ReadKey" -f $domainuser
+        $testuser = "{0}\s+Allow\s+ReadKey" -f $domainuser.replace('\', '\\')
         if ($_debug) {
             Write-Host "debug: `$testuser = $testuser"
         }
@@ -173,12 +182,12 @@ function test_registry_security($regkey){
         if ($_debug) {
             Write-Host "debug:  `$regaclstring = $regaclstring"
         }
-        return $regaclstring.Contains($testuser) 
+        return $regaclstring -match $testuser
 	}
 
 	trap{
 
-		$message ="Registry key does not exists: $regkey"
+		$message ="Registry key does not exist: $regkey"
 		write-host $message
 		send_event $message 'Error'
 		continue
@@ -507,8 +516,7 @@ foreach($folderfile in $folderfiles){
 
 $services = get-wmiobject -query "Select * from Win32_Service"
 $serviceaccessmap = get_accessmask @("servicequeryconfig","servicequeryservice","readallprop","readsecurity","serviceinterrogate")
-Write-Host "`nTesting $userfqdn for access to services"
-#is_user_in_service 'SCMANAGER'
+Write-Host "`nTesting $userfqdn for access to services.  Some services are controlled by the system and permissions cannot be changed. `nFor example, the EFS service."
 foreach ($service in $services){
 	$svc_ret = is_user_in_service $service.name
     if ($svc_ret -eq $True) {

--- a/lpu/zenoss-audit-lpu.ps1
+++ b/lpu/zenoss-audit-lpu.ps1
@@ -141,11 +141,15 @@ function is_user_in_service($service){
     $testuserperms = @('CC','LC','RP','LO','RC')
 	$servicesddlstart = [string](CMD /C "sc sdshow `"$service`"")
     $intersection = @('place','holder')
+    [regex]$re = '\w;;(\w+);.*'
     foreach ($sddlkey in $servicesddlstart.split('('))  {
         if ($sddlkey -match $usersid) {
-            $perms = [regex]::match($sddlkey, '\w;;(\w+);.*').Groups[1].value
-            $sddlperms = $perms -split '(.{2})' | ? {$_}
-            $intersection = $testuserperms | ?{$sddlperms -notcontains $_}
+            $match = $re.match($sddlkey)
+            if ($match.success -eq $true) {
+                $perms = $match.Groups[1].value
+                $sddlperms = $perms -split '(.{2})' | ? {$_}
+                $intersection = $testuserperms | ?{$sddlperms -notcontains $_}
+            }
         }
     }
 	return $intersection -eq $null

--- a/lpu/zenoss-backup-lpu.ps1
+++ b/lpu/zenoss-backup-lpu.ps1
@@ -1,0 +1,122 @@
+#
+# Copyright 2015 Zenoss Inc., All rights reserved
+#
+# DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK
+#
+# This script queries the registry and several system access permissions. Use with caution!
+#
+# This script does not backup any settings.  It will display the sddls for the following which can be
+# captured in a text file and reapplied if the LPU is removed
+#
+#    * WinRM Access
+#    * DCOM Permissions
+#    * Registry Permissions
+#    * Folder/File Permissions
+#    * Service Permissions
+#
+# It does not determine WMI Namespace or Local Group information.
+#
+# Example usage:  PS > .\zenoss-backup-lpu.ps1 > backup.txt
+
+
+function backup_winrm_access(){
+    $sddlkey = "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service"
+    $rootsddlkey = get-itemproperty $sddlkey -Name “rootSDDL”
+    Write-Output "winrm:  "$rootsddlkey.rootSDDL
+}
+
+function backup_registry_sddl($regkey){
+    $regaclitem = get-item $regkey -ea silentlycontinue
+    if ($regaclitem -ne $null) {
+        $sddl = $regaclitem.getaccesscontrol("Access").sddl
+        Write-Output $regkey":  "$sddl
+    }
+}
+
+function backup_dcom_permissions($regkey, $property) {
+    $objSDHelper = New-Object System.Management.ManagementClass Win32_SecurityDescriptorHelper
+    $objRegProperty = Get-ItemProperty $regkey -Name $property -ea SilentlyContinue
+    if ($objRegProperty -ne $null) {
+        $sddl = [string]($objSDHelper.BinarySDToSDDL($objRegProperty.$property)).SDDL
+        Write-Output $regkey":"$property":  "$sddl
+    }
+}
+
+function backup_folderfile($folderfile) {
+    $sddl = (get-item $folderfile).getaccesscontrol("Access").Sddl
+    Write-Output $folderfile":  "$sddl
+}
+
+function backup_service_sddl($service) {
+    $servicesddl = [string](CMD /C "sc sdshow `"$service`"")
+    Write-Output "{$service}:  "$servicesddl
+}
+
+###################################################
+# The least privileged user needs winrm access
+# Write out the current access
+###################################################
+Write-Output("==== WinRM Access ====")
+
+backup_winrm_access
+
+####################################################
+# The lpu needs registry key access
+# Write out the current access to the necessary keys
+####################################################
+Write-Output("`n`n==== Registry Keys Permissions ====")
+
+$registrykeys = @(
+	"HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib",
+	"HKLM:\system\currentcontrolset\control\securepipeservers\winreg",
+	"HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4D36E972-E325-11CE-BFC1-08002bE10318}",
+	"HKLM:\SYSTEM\CurrentControlSet\Services\Blfp\Parameters\Adapters",
+	"HKLM:\Software\Wow6432Node\Microsoft\Microsoft SQL Server",
+	"HKLM:\Software\Microsoft\Microsoft SQL Server"
+	)
+foreach ($registrykey in $registrykeys) {
+    backup_registry_sddl $registrykey
+}
+
+###################################################
+# The least privileged user needs DCOM access
+# Write out the current access for each registry value
+# DefaultAccessPermission may not exist, which is OK
+###################################################
+Write-Output("`n`n==== DCOM Permissions ====")
+
+$registryvaluekeys = @{
+	"MachineAccessRestriction" = "HKLM:\software\microsoft\ole";
+	"MachineLaunchRestriction" = "HKLM:\software\microsoft\ole";
+    "DefaultAccessPermission" = "HKLM:\software\microsoft\ole"
+}
+
+foreach ($registryvaluekey in $registryvaluekeys.GetEnumerator()){
+    backup_dcom_permissions $registryvaluekey.Value $registryvaluekey.Name
+}
+
+###################################################
+# The least privileged user needs folder access
+# Write out the current access for each folder
+###################################################
+Write-Output("`n`n==== Folder Permissions ====")
+
+$folderfiles = @(
+	"C:\Windows\system32\inetsrv\config"
+	)
+foreach($folderfile in $folderfiles){
+	backup_folderfile $folderfile 
+}
+
+
+###################################################
+# The least privileged user needs query access to services
+# Write out the current access for each service
+###################################################
+Write-Output("`n`n==== Service Permissions ====")
+
+$services = get-wmiobject -query "Select * from Win32_Service"
+foreach ($service in $services){
+	backup_service_sddl $service.name
+}
+

--- a/lpu/zenoss-backup-lpu.ps1
+++ b/lpu/zenoss-backup-lpu.ps1
@@ -3,10 +3,12 @@
 #
 # DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK
 #
+# Example of backing up permissions changed by the lpu script
+#
 # This script queries the registry and several system access permissions. Use with caution!
 #
 # This script does not backup any settings.  It will display the sddls for the following which can be
-# captured in a text file and reapplied if the LPU is removed
+# captured in a text file and reapplied if the LPU is removed.
 #
 #    * WinRM Access
 #    * DCOM Permissions
@@ -22,14 +24,16 @@
 function backup_winrm_access(){
     $sddlkey = "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service"
     $rootsddlkey = get-itemproperty $sddlkey -Name “rootSDDL”
-    Write-Output "winrm:  "$rootsddlkey.rootSDDL
+    $output = "winrm:  {0}" -f $rootsddlkey.rootSDDL
+    Write-Output $output
 }
 
 function backup_registry_sddl($regkey){
     $regaclitem = get-item $regkey -ea silentlycontinue
     if ($regaclitem -ne $null) {
         $sddl = $regaclitem.getaccesscontrol("Access").sddl
-        Write-Output $regkey":  "$sddl
+        $output = "{0}:  {1}" -f $regkey,$sddl
+        Write-Output $output
     }
 }
 
@@ -38,25 +42,28 @@ function backup_dcom_permissions($regkey, $property) {
     $objRegProperty = Get-ItemProperty $regkey -Name $property -ea SilentlyContinue
     if ($objRegProperty -ne $null) {
         $sddl = [string]($objSDHelper.BinarySDToSDDL($objRegProperty.$property)).SDDL
-        Write-Output $regkey":"$property":  "$sddl
+        $output = "{0}:{1}:  {2}" -f $regkey,$property,$sddl
+        Write-Output $output
     }
 }
 
 function backup_folderfile($folderfile) {
     $sddl = (get-item $folderfile).getaccesscontrol("Access").Sddl
-    Write-Output $folderfile":  "$sddl
+    $output = "{0}:  {1}" -f $folderfile,$sddl
+    Write-Output $output
 }
 
 function backup_service_sddl($service) {
     $servicesddl = [string](CMD /C "sc sdshow `"$service`"")
-    Write-Output "{$service}:  "$servicesddl
+    $output = "{0}:  {1}" -f $service,$servicesddl
+    Write-Output $output
 }
 
 ###################################################
 # The least privileged user needs winrm access
 # Write out the current access
 ###################################################
-Write-Output("==== WinRM Access ====")
+Write-Output "==== WinRM Access ===="
 
 backup_winrm_access
 
@@ -64,7 +71,7 @@ backup_winrm_access
 # The lpu needs registry key access
 # Write out the current access to the necessary keys
 ####################################################
-Write-Output("`n`n==== Registry Keys Permissions ====")
+Write-Output "`n`n==== Registry Keys Permissions ===="
 
 $registrykeys = @(
 	"HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib",
@@ -83,7 +90,7 @@ foreach ($registrykey in $registrykeys) {
 # Write out the current access for each registry value
 # DefaultAccessPermission may not exist, which is OK
 ###################################################
-Write-Output("`n`n==== DCOM Permissions ====")
+Write-Output "`n`n==== DCOM Permissions ===="
 
 $registryvaluekeys = @{
 	"MachineAccessRestriction" = "HKLM:\software\microsoft\ole";
@@ -99,7 +106,7 @@ foreach ($registryvaluekey in $registryvaluekeys.GetEnumerator()){
 # The least privileged user needs folder access
 # Write out the current access for each folder
 ###################################################
-Write-Output("`n`n==== Folder Permissions ====")
+Write-Output "`n`n==== Folder Permissions ===="
 
 $folderfiles = @(
 	"C:\Windows\system32\inetsrv\config"
@@ -113,7 +120,7 @@ foreach($folderfile in $folderfiles){
 # The least privileged user needs query access to services
 # Write out the current access for each service
 ###################################################
-Write-Output("`n`n==== Service Permissions ====")
+Write-Output "`n`n==== Service Permissions ===="
 
 $services = get-wmiobject -query "Select * from Win32_Service"
 foreach ($service in $services){

--- a/lpu/zenoss-lpu.ps1
+++ b/lpu/zenoss-lpu.ps1
@@ -262,8 +262,8 @@ function set_registry_sd_value($regkey, $property, $usersid, $accessMask){
         }
     }
     else {
-        $message = "Property $property does not exist in registry key $regkey"
-        send_event $message
+        $message = "Property $property does not exist in registry key $regkey.  Nothing to update."
+        write-host $message
     }
 
 	trap{

--- a/lpu/zenoss-lpu.ps1
+++ b/lpu/zenoss-lpu.ps1
@@ -1,23 +1,29 @@
 #
-# Copyright 2014 Zenoss Inc., All rights reserved
+# Copyright 2015 Zenoss Inc., All rights reserved
 #
 # DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK
 #
 # This script modifies the registry and several system access permissions. Use with caution!
+#    Backup your settings before executing!
 #
 # To make sure you understand this you'll need to uncomment out the section at the bottom of the script before you can use it.
 # Each section in the Execution Center at the bottom describes what permissions need to be set
 #
+# Information:
 # This script is not intended for Clusters.  Monitoring a cluster requires local administrator access
 #
 # Windows Server 2003 is not supported using this script.  You can manually apply the appropriate permissions
 # using this script as a guide.
 #
+# Some service permissions cannot be changed with this script.  The administrator does not have write object access
+# to system owned services such as EFS(Encrypted File Service) or gpsvc(Group Policy Client).
 #
 #########################################################################################
 #                                                                                       #
 #  WARNINGS:                                                                            #
 #  DO NOT DELETE USER WITHOUT BACKING OUT CHANGES MADE BY LPU SCRIPT!                   #
+#      Run zenoss-audit-lpu.ps1 to see which changes will be made and make a backup     #
+#      of your settings.                                                                #
 #  DO NOT RUN THIS SCRIPT ON A WINDOWS SERVER WITH A HYPER-V ROLE.  IT WILL RENDER THE  #
 #       SERVER INACCESSIBLE                                                             #
 #  DO NOT RUN THE DCOM PERMISSIONS PORTION OF THIS SCRIPT WHEN THE CERTIFICATE          #
@@ -150,7 +156,12 @@ function add_user_to_service($service, $accessMask){
 	if(($servicesddlstart.contains($usersid) -eq $False) -or ($force_update -eq $true)){
 		$servicesddlnew = update_sddl $servicesddlstart $usersid $accessMask
 		$ret = CMD /C "sc sdset $service $servicesddlnew"
-		$message = "User: $userfqdn added to service"
+        if ($ret[0] -match '.FAILED.') {
+            $reason = $ret[2]
+            $message = "User: $userfqdn was not added to service $service.`n`tReason:  $reason"
+        } else {
+            $message = "User: $userfqdn added to service $service."
+        }
 		send_event $message 'Information'
 	}
 	else{
@@ -376,6 +387,12 @@ function add_ace_to_namespace($accessMask, $namespaceParams){
         throw "Failed to get security descriptor for namespace: $namespace"
     }
 	$objACL = $currentSecurityDescriptor.Descriptor
+    # check if user has permissions already
+    foreach ($acl in $objACL.DACL) {
+        if ($acl.Trustee.SIDString -eq $usersid) {
+            return $true
+        }
+    }
 
 	$objACE = (New-Object System.Management.ManagementClass("win32_Ace")).CreateInstance()
 	$objACE.AccessMask = $accessMask


### PR DESCRIPTION
changes to make the lpu audit script work better by using regexes.
changed lpu script so that we do not add user to namespaces more than once and do not show misleading error when setting dcom permissions
added example backup script