### PR TITLE
Fixed some errors

### DIFF
--- a/lpu/zenoss-lpu.ps1
+++ b/lpu/zenoss-lpu.ps1
@@ -84,6 +84,16 @@ if ($hyperv -ne $null) {
 	write-host "Hyper-V detected.  Exiting"
 	exit
 }
+
+if (Test-Path HKLM:\SOFTWARE\zenoss){
+    Write-host "Script has already run, exiting"
+    return
+
+}else{
+    Write-host "Script hasn't run, proceeding..."
+
+}
+
 # The following values will be set at runtime. They are place holders here.
 $usersid
 
@@ -565,3 +575,7 @@ $message = "Zenoss Resource Manager security permissions have been set for $user
 write-output $message
 send_event $message 'Information'
 By removing this line and the line before Execution Center you understand the risks associated with script execution. #>
+
+#Tattoo the registry
+md HKLM:\SOFTWARE\zenoss
+New-ItemProperty HKLM:\SOFTWARE\zenoss -name 'LoginScript' -Value "1"

--- a/lpu/zenoss-winrm.ps1
+++ b/lpu/zenoss-winrm.ps1
@@ -43,7 +43,7 @@ function Enable-FirewallRule {
     }
 }
 
-#<# Remove this and the final line of the script to enable execution
+<# Remove this and the final line of the script to enable execution
 
 # Check to see if we're on domain or local
 $onDomain = $False
@@ -108,4 +108,16 @@ else {
     netsh firewall add portopening TCP 5985 "HTTP"
     netsh firewall set service type = fileandprint mode = enable
 }
-#Remove this line to execute. #>
+Remove this line to execute. #>
+
+#make a local groupif not exist
+
+$cn = [ADSI]"WinNT://$env:computername"
+$group = $cn.Create("Group","WinRMRemoteWMIUsers__")
+$group.setinfo()
+$group.description = "WinRMRemoteWMIUsers__"
+$group.SetInfo()
+
+
+#add a user to a local group
+net localgroup "WinRMRemoteWMIUsers__" "Whoever@tu.com"  /Add


### PR DESCRIPTION
Noticed broken block commenting on the WinRM Script.  By placing a comment before the `<#` character, the whole block will not be properly escaped during code execution.  This defeats the purpose of the 'remove these lines to execute' code structure.  The fix was removing the extra `#`.  

Additionally, my customer informed me that in some cases, a local group "WinRMRemoteWMIUsers__" may not be present on the machine, which is a dependency.  I've added a line to create these groups, and also allowed for a user to add the designated LPU to the group.

Finally, to speed execution, I've added checking for past execution of the script, to help when used as a Group Policy Login or Start Up script.  Now, it will check for a registry key tattoo, which is created when the script runs the first time.
