### PR TITLE
Added script for remove user from local groups, fixed backup script, …

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -61,9 +61,9 @@ To remove users from a group, you could simply use a GPO.
 
 The following groups are either local to a server or are at the domain level.
 * "Performance Monitor Users",
-* "Performance Log Users", 
-* "Event Log Readers", 
-* "Distributed COM Users", 
+* "Performance Log Users",
+* "Event Log Readers",
+* "Distributed COM Users",
 * "WinRMRemoteWMIUsers__"
 
 === “Read Folder” access to "C:\Windows\system32\inetsrv\config" if it exists ===
@@ -81,8 +81,8 @@ To backup a service sddl you could do something like the following on each servi
 
 We assign the following permissions:
 * SERVICE_QUERY_CONFIG
-* SERVICE_QUERY_STATUS 
-* SERVICE_INTERROGATE 
+* SERVICE_QUERY_STATUS
+* SERVICE_INTERROGATE
 * READ_CONTROL
 * SERVICE_START
 
@@ -93,4 +93,4 @@ Some services are owned by the SYSTEM account and the permissions cannot be alte
     psexec.exe -s cmd
 * You can then execute the powershell script to update the system owned service permissions.
 
-    powershell -file "zenoss-system-services.ps1 -u zenny@zenoss.com"
+    powershell -file zenoss-system-services.ps1 -u zenny@zenoss.com

--- a/lpu/zenoss-backup-lpu.ps1
+++ b/lpu/zenoss-backup-lpu.ps1
@@ -22,7 +22,7 @@
 
 function backup_winrm_access(){
     $sddlkey = "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service"
-    $rootsddlkey = get-itemproperty $sddlkey -Name “rootSDDL”
+    $rootsddlkey = get-itemproperty $sddlkey -Name "rootSDDL"
     $output = "winrm:  {0}" -f $rootsddlkey.rootSDDL
     Write-Output $output
 }
@@ -84,7 +84,7 @@ $folderfiles = @(
 	"C:\Windows\system32\inetsrv\config"
 	)
 foreach($folderfile in $folderfiles){
-	backup_folderfile $folderfile 
+	backup_folderfile $folderfile
 }
 
 
@@ -98,4 +98,3 @@ $services = get-wmiobject -query "Select * from Win32_Service"
 foreach ($service in $services){
 	backup_service_sddl $service.name
 }
-

--- a/lpu/zenoss-remove-groups.ps1
+++ b/lpu/zenoss-remove-groups.ps1
@@ -1,0 +1,99 @@
+#
+# Copyright 2019 Zenoss Inc., All rights reserved
+#
+# DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK
+#
+# This script removes users from WMI local groups in which users have been added by the
+# "zenoss-lpu.ps1" script
+
+<#
+    .SYNOPSIS
+    Remove users from WMI local groups
+    .DESCRIPTION
+    This script removes users from WMI local groups in which users have been added by the "zenoss-lpu.ps1" script
+    .INPUT
+    -u or -user to specify the user name.  Enter just the user name for a local user and user@domain.com for a domain user.
+    .EXAMPLE
+    Domain account
+    zenoss-remove-groups.ps1 -u zenny@zenoss.com
+    .EXAMPLE
+    Local account
+    zenoss-remove-groups.ps1 -u benny
+#>
+
+########################################
+#  ------------------------------------
+#  ----------- Arguments  -------------
+#  ------------------------------------
+########################################
+
+param(
+	[Parameter(HelpMessage="User account to provide Zenoss permissions")]
+	[Alias('user', 'u')]
+	[string]
+	$login
+	)
+
+########################################
+#  ------------------------------------
+#  ----------- Initialization  --------
+#  ------------------------------------
+########################################
+
+# The following values will be set at runtime. They are place holders here.
+$usersid
+
+# Set account information
+
+if($login.contains("@")){
+	$arrlogin = $login.split("@")
+	$arrdomain = $arrlogin[1].split(".")
+    $domain = $arrdomain[0]
+	$username = $arrlogin[0]
+	$userfqdn = $login
+}
+else{
+	$domain = $env:COMPUTERNAME
+	$username = $login
+	$userfqdn = "{1}\{0}" -f $username, $domain
+}
+
+########################################
+#  ------------------------------------
+#  -----------  Functions -------------
+#  ------------------------------------
+########################################
+
+function remove_user_from_group($groupname) {
+    try
+    {
+        $objADSI = [ADSI]"WinNT://./$groupname,group"
+        $objADSIUser = [ADSI]"WinNT://$domain/$username"
+        [array]$objMembers = $objADSI.psbase.Invoke("Members")
+        $objADSI.psbase.Invoke("Remove",$objADSIUser.psbase.path)
+        $message = "User removed from group: $groupname"
+        write-host $message
+    }
+    catch
+    {
+        $message = "[$groupname] $($_.Exception.InnerException.Message)"
+        write-host $message
+        continue
+    }
+}
+
+$localgroups = @(
+	"S-1-5-32-558",
+	"S-1-5-32-559",
+	"S-1-5-32-573",
+	"S-1-5-32-562",
+	"WinRMRemoteWMIUsers__"
+	)
+
+  foreach ($localgroup in $localgroups) {
+      if ($localgroup.StartsWith('S-1-5-32-')) {
+          $GrObj = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $localgroup;
+          $localgroup = $GrObj.Translate([System.Security.Principal.NTAccount]).Value.split('\')[1]
+      }
+  	remove_user_from_group $localgroup
+  }


### PR DESCRIPTION
* Fixed: revert LPU script we have developed - require changes to work with SYSTEM services.
* Fixed: the .\zenoss-lpu.ps1 fails to add the user to the needed groups.
* Some services are owned by the SYSTEM account and the permissions cannot be altered by the administrator. 
* Added zenoss-remove-groups.ps1 script