### PR TITLE
Add RemoteManagementUsers to $localgroups list

### DIFF
--- a/lpu/zenoss-lpu.ps1
+++ b/lpu/zenoss-lpu.ps1
@@ -499,14 +499,15 @@ foreach ($registrykey in $registrykeys) {
 #    "Performance Log Users",
 #    "Event Log Readers",
 #    "Distributed COM Users",
-#    "WinRMRemoteWMIUsers__"
+#    "WinRMRemoteWMIUsers__",
+#    "Remote Management Users"
 ########################################################################
 $localgroups = @(
 	"S-1-5-32-558",
 	"S-1-5-32-559",
 	"S-1-5-32-573",
-	"S-1-5-32-562",
-	"WinRMRemoteWMIUsers__"
+	"WinRMRemoteWMIUsers__",
+	"Remote Management Users"
 	)
 
 foreach ($localgroup in $localgroups) {

--- a/lpu/zenoss-lpu.ps1
+++ b/lpu/zenoss-lpu.ps1
@@ -506,6 +506,7 @@ $localgroups = @(
 	"S-1-5-32-558",
 	"S-1-5-32-559",
 	"S-1-5-32-573",
+	"S-1-5-32-562",
 	"WinRMRemoteWMIUsers__",
 	"Remote Management Users"
 	)


### PR DESCRIPTION
Fixes ZPS-8530.

Added Remote Management Users to $localgroups list in zenoss-lpu.ps1 to grant access for least-privileged users to this group.